### PR TITLE
Chirpstack Metrics (lorawan)

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,6 +110,27 @@ prom2waggle = {
     "node_hwmon_temp_celsius": "sys.hwmon",
     "node_cooling_device_cur_state": "sys.cooling",
     "node_cooling_device_max_state": "sys.cooling_max",
+    # ChirpStack Gateway Bridge (lorawan gateway)
+        # HELP The percentage of upstream datagrams that were acknowledged.
+        # TYPE gauge
+    "backend_semtechdup_gateway_ack_rate": "lora.gateway.ack_rate",
+        # HELP The number of ack-rates reported.
+        # TYPE counter
+    "backend_semtechudp_gateway_ack_rate_count": "lora.gateway.ack_rate_count",
+        # HELP The number of gateway connections received by the backend.
+        # TYPE counter
+    "backend_semtechudp_gateway_connect_count": "lora.gateway.connect_count",
+        # HELP The number of gateways that disconnected from the backend.
+        # TYPE counter
+    "backend_semtechudp_gateway_diconnect_count": "lora.gateway.disconnect_count",
+        # HELP The number of UDP packets received by the backend (per packet_type).
+        # TYPE counter
+    "backend_semtechudp_udp_received_count": "lora.gateway.udp_received_count",
+        # HELP The number of UDP packets sent by the backend (per packet_type).
+        # TYPE counter
+    "backend_semtechudp_udp_sent_count": "lora.gateway.udp_sent_count",
+    # ChirpStack Server (lorawan network server)
+    #TODO: left off here - flozano 2024-02-24
 }
 
 # mapping of gps metric to it's error estimate key

--- a/main.py
+++ b/main.py
@@ -23,7 +23,15 @@ tegrastats_queue = Queue()
 jetsonclocks_queue = Queue()
 
 
-def get_node_exporter_metrics(url):
+def get_prometheus_metrics(url):
+    """
+    Fetches the prometheus metrics from the url.
+
+    Args:
+        url: the url of the prometheus metrics endpoint
+    Returns:
+        the metrics as a string
+    """
     with urlopen(url) as f:
         return f.read().decode()
 
@@ -474,7 +482,7 @@ def add_system_metrics(args, messages):
     timestamp = time.time_ns()
 
     logging.info("collecting system metrics from %s", args.metrics_url)
-    text = get_node_exporter_metrics(args.metrics_url)
+    text = get_prometheus_metrics(args.metrics_url)
 
     for family in text_string_to_metric_families(text):
         for sample in family.samples:
@@ -577,7 +585,7 @@ def add_chirpstack_server_metrics(args, messages):
     timestamp = time.time_ns()
     
     logging.info("collecting ChirpStack server metrics from %s", args.chirpstack_metrics_url)
-    text = get_node_exporter_metrics(args.chirpstack_metrics_url)
+    text = get_prometheus_metrics(args.chirpstack_metrics_url)
         
     for family in text_string_to_metric_families(text):
         for sample in family.samples:
@@ -601,7 +609,7 @@ def add_chirpstack_gateway_bridge_metrics(args, messages):
     timestamp = time.time_ns()
 
     logging.info("collecting ChirpStack gateway bridge metrics from %s", args.chirpstack_gateway_metrics_url)
-    text = get_node_exporter_metrics(args.chirpstack_gateway_metrics_url)
+    text = get_prometheus_metrics(args.chirpstack_gateway_metrics_url)
 
     for family in text_string_to_metric_families(text):
         for sample in family.samples:

--- a/main.py
+++ b/main.py
@@ -113,24 +113,32 @@ prom2waggle = {
     # ChirpStack Gateway Bridge (lorawan gateway)
         # HELP The percentage of upstream datagrams that were acknowledged.
         # TYPE gauge
-    "backend_semtechdup_gateway_ack_rate": "lora.gateway.ack_rate",
+    "backend_semtechdup_gateway_ack_rate": "sys.lora.gateway.ack_rate",
         # HELP The number of ack-rates reported.
         # TYPE counter
-    "backend_semtechudp_gateway_ack_rate_count": "lora.gateway.ack_rate_count",
+    "backend_semtechudp_gateway_ack_rate_count": "sys.lora.gateway.ack_rate_count",
         # HELP The number of gateway connections received by the backend.
         # TYPE counter
-    "backend_semtechudp_gateway_connect_count": "lora.gateway.connect_count",
+    "backend_semtechudp_gateway_connect_count": "sys.lora.gateway.connect_count",
         # HELP The number of gateways that disconnected from the backend.
         # TYPE counter
-    "backend_semtechudp_gateway_diconnect_count": "lora.gateway.disconnect_count",
+    "backend_semtechudp_gateway_diconnect_count": "sys.lora.gateway.disconnect_count",
         # HELP The number of UDP packets received by the backend (per packet_type).
         # TYPE counter
-    "backend_semtechudp_udp_received_count": "lora.gateway.udp_received_count",
+    "backend_semtechudp_udp_received_count": "sys.lora.gateway.udp_received_count",
         # HELP The number of UDP packets sent by the backend (per packet_type).
         # TYPE counter
-    "backend_semtechudp_udp_sent_count": "lora.gateway.udp_sent_count",
+    "backend_semtechudp_udp_sent_count": "sys.lora.gateway.udp_sent_count",
     # ChirpStack Server (lorawan network server)
-    #TODO: left off here - flozano 2024-02-24
+        # HELP gateway_backend_mqtt_events Number of events received.
+        # TYPE gateway_backend_mqtt_events counter
+    "gateway_backend_mqtt_events_total": "sys.lora.server.gateway_backend_mqtt_events",
+        # HELP uplink_count Number of received uplinks (after deduplication).
+        # TYPE uplink_count counter
+    "uplink_count_total": "sys.lora.server.uplink_count",
+        # HELP gateway_backend_mqtt_commands Number of commands sent.
+        # TYPE gateway_backend_mqtt_commands counter,
+    "gateway_backend_mqtt_commands_total": "sys.lora.server.gateway_backend_mqtt_commands",
 }
 
 # mapping of gps metric to it's error estimate key


### PR DESCRIPTION
This pull request adds support for ChirpStack/lorawan metrics.

Improvements to metric collection:

* Renamed the function `get_node_exporter_metrics` to `get_prometheus_metrics` and added a docstring to clarify its purpose.

Addition of ChirpStack metrics:

* Added new ChirpStack Gateway Bridge and Server metrics to the metrics mapping dictionary.
* Introduced `add_chirpstack_server_metrics` and `add_chirpstack_gateway_bridge_metrics` functions to collect and publish Prometheus metrics from the ChirpStack server and gateway bridge, respectively.
* Added new command-line arguments to specify the ChirpStack server and gateway bridge metrics URLs.
* Updated the `main_runner` function to call the new ChirpStack metrics collection functions and handle exceptions.